### PR TITLE
Replace JODA with java.time Package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ ext {
   jacocoVersion = '0.8.1'
   checkstyleVersion = '8.10'
   pmdVersion = '5.8.1'
-  guavaVersion = '20.0'
   swaggerVersion = '2.7.0'
 }
 
@@ -35,7 +34,6 @@ dependencies {
   
   compile group: 'org.springframework', name: 'spring-context-support'
   
-  compile group: 'com.google.guava', name: 'guava', version: guavaVersion
   compile group: 'com.github.ben-manes.caffeine', name: 'caffeine'
   compile group: 'org.liquibase', name: 'liquibase-core'
   compile group: 'io.springfox', name: 'springfox-swagger2', version: swaggerVersion

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ ext {
   checkstyleVersion = '8.10'
   pmdVersion = '5.8.1'
   guavaVersion = '20.0'
-  jadiraVersion = '7.0.0.CR1'
   swaggerVersion = '2.7.0'
 }
 
@@ -36,11 +35,8 @@ dependencies {
   
   compile group: 'org.springframework', name: 'spring-context-support'
   
-  compile group: 'joda-time', name: 'joda-time'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda'
   compile group: 'com.google.guava', name: 'guava', version: guavaVersion
   compile group: 'com.github.ben-manes.caffeine', name: 'caffeine'
-  compile group: 'org.jadira.usertype', name: 'usertype.core', version: jadiraVersion
   compile group: 'org.liquibase', name: 'liquibase-core'
   compile group: 'io.springfox', name: 'springfox-swagger2', version: swaggerVersion
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: swaggerVersion

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <java.version>1.8</java.version>
     <guava.version>20.0</guava.version>
     <swagger.version>2.7.0</swagger.version>
-    <jadira.version>7.0.0.CR1</jadira.version>
   </properties>
   
   <dependencies>
@@ -51,12 +50,6 @@
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <!-- jadira custom Hibernate type mappings -->
-    <dependency>
-      <groupId>org.jadira.usertype</groupId>
-      <artifactId>usertype.core</artifactId>
-      <version>${jadira.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
@@ -73,14 +66,6 @@
     </dependency>
     
     <!-- Dependencies for Miscellaneous Functionality -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-joda</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <guava.version>20.0</guava.version>
     <swagger.version>2.7.0</swagger.version>
   </properties>
   
@@ -66,11 +65,6 @@
     </dependency>
     
     <!-- Dependencies for Miscellaneous Functionality -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
 
     <!-- Dependencies for Swagger -->
     <dependency>

--- a/src/main/java/com/leanstacks/ws/model/ReferenceEntity.java
+++ b/src/main/java/com/leanstacks/ws/model/ReferenceEntity.java
@@ -1,12 +1,11 @@
 package com.leanstacks.ws.model;
 
 import java.io.Serializable;
+import java.time.Instant;
 
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import javax.validation.constraints.NotNull;
-
-import org.joda.time.DateTime;
 
 /**
  * The parent class for all reference entities (i.e. reference data as opposed to transactional data).
@@ -51,19 +50,19 @@ public class ReferenceEntity implements Serializable {
      * The timestamp at which the entity's values may be applied or used by the system.
      */
     @NotNull
-    private DateTime effectiveAt;
+    private Instant effectiveAt;
 
     /**
      * The timestamp at which the entity's values cease to be used by the system. If <code>null</code> the entity is not
      * expired.
      */
-    private DateTime expiresAt;
+    private Instant expiresAt;
 
     /**
      * The timestamp when this entity instance was created.
      */
     @NotNull
-    private DateTime createdAt;
+    private Instant createdAt;
 
     public Long getId() {
         return id;
@@ -97,27 +96,27 @@ public class ReferenceEntity implements Serializable {
         this.ordinal = ordinal;
     }
 
-    public DateTime getEffectiveAt() {
+    public Instant getEffectiveAt() {
         return effectiveAt;
     }
 
-    public void setEffectiveAt(final DateTime effectiveAt) {
+    public void setEffectiveAt(final Instant effectiveAt) {
         this.effectiveAt = effectiveAt;
     }
 
-    public DateTime getExpiresAt() {
+    public Instant getExpiresAt() {
         return expiresAt;
     }
 
-    public void setExpiresAt(final DateTime expiresAt) {
+    public void setExpiresAt(final Instant expiresAt) {
         this.expiresAt = expiresAt;
     }
 
-    public DateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(final DateTime createdAt) {
+    public void setCreatedAt(final Instant createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/leanstacks/ws/model/TransactionalEntity.java
+++ b/src/main/java/com/leanstacks/ws/model/TransactionalEntity.java
@@ -1,6 +1,7 @@
 package com.leanstacks.ws.model;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.UUID;
 
 import javax.persistence.GeneratedValue;
@@ -11,8 +12,6 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Version;
 import javax.validation.constraints.NotNull;
-
-import org.joda.time.DateTime;
 
 import com.leanstacks.ws.util.RequestContext;
 
@@ -85,7 +84,7 @@ public class TransactionalEntity implements Serializable {
             readOnly = true,
             example = "1499418339522")
     @NotNull
-    private DateTime createdAt;
+    private Instant createdAt;
 
     /**
      * A reference to the entity or process which most recently updated this entity instance.
@@ -105,7 +104,7 @@ public class TransactionalEntity implements Serializable {
             position = Integer.MAX_VALUE - 100,
             readOnly = true,
             example = "1499418343681")
-    private DateTime updatedAt;
+    private Instant updatedAt;
 
     public Long getId() {
         return id;
@@ -139,11 +138,11 @@ public class TransactionalEntity implements Serializable {
         this.createdBy = createdBy;
     }
 
-    public DateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(final DateTime createdAt) {
+    public void setCreatedAt(final Instant createdAt) {
         this.createdAt = createdAt;
     }
 
@@ -155,11 +154,11 @@ public class TransactionalEntity implements Serializable {
         this.updatedBy = updatedBy;
     }
 
-    public DateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 
-    public void setUpdatedAt(final DateTime updatedAt) {
+    public void setUpdatedAt(final Instant updatedAt) {
         this.updatedAt = updatedAt;
     }
 
@@ -178,7 +177,7 @@ public class TransactionalEntity implements Serializable {
         }
         setCreatedBy(username);
 
-        setCreatedAt(new DateTime());
+        setCreatedAt(Instant.now());
     }
 
     /**
@@ -196,7 +195,7 @@ public class TransactionalEntity implements Serializable {
         }
         setUpdatedBy(username);
 
-        setUpdatedAt(new DateTime());
+        setUpdatedAt(Instant.now());
     }
 
     /**


### PR DESCRIPTION
Fixes #47 

Removes the JODA, and related, dependencies from the project. Replace JODA classes with appropriate classes from the `java.time` package.