### PR TITLE
Docker Java 8 Build 181

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # From the OpenJDK image
-FROM openjdk:8u151-jre-alpine3.7
+FROM openjdk:8u181-jre-slim-stretch
 
 # Java Options
 ENV JAVA_OPTS="-server -Xms1024m -Xmx1024m -XX:+UseParallelGC -verbose:gc"


### PR DESCRIPTION
Fixes #52 

Update Dockerfile to use the latest available OpenJDK Java 8 image. It is using the JRE for Java 8 build 181. No alpine image available. Using Debian Stretch, slim build.